### PR TITLE
swapping out HashMap for OrderMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ tokio-timer = "0.1"
 hdrsample = "3.0"
 twox-hash = "1.0"
 log = "0.3"
+ordermap = "0.2"
 
 [dev-dependencies]
 tokio-core = "0.1"

--- a/examples/multithread.rs
+++ b/examples/multithread.rs
@@ -32,7 +32,7 @@ fn main() {
 
         let spawn_start = Timing::start();
         thread::spawn(move || {
-            for i in 0..1_000_000 {
+            for i in 0..100_000_000 {
                 let loop_start = Timing::start();
                 let mut r = metrics.recorder();
                 r.incr(&loop_counter, 1);

--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -2,8 +2,10 @@ use super::{Sample, CounterKey, GaugeKey, StatKey};
 use futures::{Async, Poll, Future, Stream, task};
 use futures::sync::{BiLock, mpsc};
 use hdrsample::Histogram;
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use twox_hash::RandomXxHashBuilder;
+use ordermap::OrderMap;
+use twox_hash::XxHash;
 
 pub fn new(samples: mpsc::UnboundedReceiver<Sample>,
            report: BiLock<Report>,
@@ -80,16 +82,16 @@ impl Future for Aggregator {
 /// Stores aggregated metrics.
 #[derive(Clone)]
 pub struct Report {
-    pub counters: HashMap<CounterKey, u64, RandomXxHashBuilder>,
-    pub gauges: HashMap<GaugeKey, u64, RandomXxHashBuilder>,
-    pub stats: HashMap<StatKey, Histogram<u64>, RandomXxHashBuilder>,
+    pub counters: OrderMap<CounterKey, u64, RandomXxHashBuilder>,
+    pub gauges: OrderMap<GaugeKey, u64, RandomXxHashBuilder>,
+    pub stats: OrderMap<StatKey, Histogram<u64>, RandomXxHashBuilder>,
 }
 impl Default for Report {
     fn default() -> Report {
         Report {
-            counters: HashMap::default(),
-            gauges: HashMap::default(),
-            stats: HashMap::default(),
+            counters: OrderMap::default(),
+            gauges: OrderMap::default(),
+            stats: OrderMap::default(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! by `Reporter` and `Sample`.
 //!
 //! Labels are stored in a `BTreeMap`, because they are used as keys in the `Report`'s
-//! `HashMap` (and so we need to be able to derive `Hash` on the set of labels).
+//! `OrderMap` (and so we need to be able to derive `Hash` on the set of labels).
 //!
 //! At times, metric keys must be cloned---specifically, when creating a new entry in a
 //! `Sample` or `Report`.
@@ -23,6 +23,7 @@ extern crate tokio_timer;
 #[macro_use]
 extern crate log;
 extern crate twox_hash;
+extern crate ordermap;
 
 use futures::sync::{BiLock, mpsc};
 

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -1,8 +1,9 @@
 use super::{CounterKey, GaugeKey, StatKey};
 use futures::sync::mpsc;
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::mem;
 use twox_hash::RandomXxHashBuilder;
+use ordermap::OrderMap;
 
 pub fn factory(tx: mpsc::UnboundedSender<Sample>) -> RecorderFactory {
     RecorderFactory(tx)
@@ -72,16 +73,16 @@ impl Drop for Recorder {
 /// Stores the results from a a `Record` instance.
 #[derive(Clone, Debug)]
 pub struct Sample {
-    pub counters: HashMap<CounterKey, u64, RandomXxHashBuilder>,
-    pub gauges: HashMap<GaugeKey, u64, RandomXxHashBuilder>,
-    pub stats: HashMap<StatKey, VecDeque<u64>, RandomXxHashBuilder>,
+    pub counters: OrderMap<CounterKey, u64, RandomXxHashBuilder>,
+    pub gauges: OrderMap<GaugeKey, u64, RandomXxHashBuilder>,
+    pub stats: OrderMap<StatKey, VecDeque<u64>, RandomXxHashBuilder>,
 }
 impl Default for Sample {
     fn default() -> Sample {
         Sample {
-            counters: HashMap::default(),
-            gauges: HashMap::default(),
-            stats: HashMap::default(),
+            counters: OrderMap::default(),
+            gauges: OrderMap::default(),
+            stats: OrderMap::default(),
         }
     }
 }


### PR DESCRIPTION
Swapping out OrderMap for HashMap resulted in a pretty dramatic speedup for our multithread example. While running with 1B loop iterations, runtime under a profiler (linux `perf`) dropped from 48 minutes to 14 minutes.