### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tacho"
-description = "Tokio-aware metrics library."
-version = "0.2.0"
+description = "A prometheus-focused metrics library"
+version = "0.3.0"
 authors = ["Steve Jenson <stevej@buoyant.io>",
            "Oliver Gould <oliver@buoyant.io>"]
 repository = "https://github.com/BuoyantIO/tacho"
@@ -9,12 +9,12 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-futures = "0.1"
-tokio-timer = "0.1"
 hdrsample = "3.0"
 twox-hash = "1.0"
 log = "0.3"
 
 [dev-dependencies]
+tokio-timer = "0.1"
+futures = "0.1"
 tokio-core = "0.1"
 pretty_env_logger = "0.1"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tacho #
 
-A [Tokio][tokio]/[Futures][futures]-aware metrics library.
+A [Prometheus][prom]-focused metrics library for Rust.
 
 - Inspired by [finagle-stats][finagle].
 - Supports [Prometheus][prom]-style labels and formatting.
@@ -16,6 +16,4 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 [finagle]: https://github.com/twitter/finagle
-[futures]: https://github.com/alexcrichton/futures-rs
 [prom]: https://prometheus.io
-[tokio]: https://tokio.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,7 @@
 
 // TODO use atomics when we have them.
 
-extern crate futures;
 extern crate hdrsample;
-extern crate tokio_timer;
 #[macro_use]
 extern crate log;
 extern crate twox_hash;
@@ -173,7 +171,9 @@ impl Counter {
     }
 
     pub fn incr(&mut self, v: u64) {
-        let mut counters = self.counters.write().expect("failed to obtain write lock for counter");
+        let mut counters = self.counters
+            .write()
+            .expect("failed to obtain write lock for counter");
         if let Some(mut curr) = counters.get_mut(&self.key) {
             *curr += v;
             return;
@@ -197,7 +197,9 @@ impl Gauge {
     }
 
     pub fn set(&mut self, v: u64) {
-        let mut gauges = self.gauges.write().expect("failed to obtain write lock for gauge");
+        let mut gauges = self.gauges
+            .write()
+            .expect("failed to obtain write lock for gauge");
         if let Some(mut curr) = gauges.get_mut(&self.key) {
             *curr = v;
             return;
@@ -230,7 +232,9 @@ impl Stat {
 
     pub fn add_values(&mut self, vs: &[u64]) {
         trace!("histo record {:?} {:?}", self.key, vs);
-        let mut stats = self.stats.write().expect("failed to obtain write lock for stat");
+        let mut stats = self.stats
+            .write()
+            .expect("failed to obtain write lock for stat");
         if let Some(mut histo) = stats.get_mut(&self.key) {
             for v in vs {
                 if let Err(e) = histo.record(*v) {
@@ -272,7 +276,8 @@ mod tests {
         {
             let report = reporter.peek();
             {
-                let k = report.counters()
+                let k = report
+                    .counters()
                     .keys()
                     .find(|k| k.name() == "happy_accidents")
                     .expect("expected counter");
@@ -280,17 +285,22 @@ mod tests {
                 assert_eq!(report.counters().get(&k), Some(&1));
             }
             {
-                let k = report.gauges()
+                let k = report
+                    .gauges()
                     .keys()
                     .find(|k| k.name() == "paint_level")
                     .expect("expected gauge");
                 assert_eq!(k.labels.get("joy"), Some(&"painting".to_string()));
                 assert_eq!(report.gauges().get(&k), Some(&2));
             }
-            assert_eq!(report.gauges().keys().find(|k| k.name() == "brush_width"),
+            assert_eq!(report
+                           .gauges()
+                           .keys()
+                           .find(|k| k.name() == "brush_width"),
                        None);
             {
-                let k = report.stats()
+                let k = report
+                    .stats()
                     .keys()
                     .find(|k| k.name() == "stroke_len")
                     .expect("expected stat");
@@ -307,7 +317,8 @@ mod tests {
         {
             let report = reporter.peek();
             {
-                let k = report.counters()
+                let k = report
+                    .counters()
                     .keys()
                     .find(|k| k.name() == "happy_accidents")
                     .expect("expected counter");
@@ -315,7 +326,8 @@ mod tests {
                 assert_eq!(report.counters().get(&k), Some(&3));
             }
             {
-                let k = report.gauges()
+                let k = report
+                    .gauges()
                     .keys()
                     .find(|k| k.name() == "paint_level")
                     .expect("expected gauge");
@@ -323,7 +335,8 @@ mod tests {
                 assert_eq!(report.gauges().get(&k), Some(&2));
             }
             {
-                let k = report.gauges()
+                let k = report
+                    .gauges()
                     .keys()
                     .find(|k| k.name() == "brush_width")
                     .expect("expected gauge");
@@ -331,7 +344,8 @@ mod tests {
                 assert_eq!(report.gauges().get(&k), Some(&5));
             }
             {
-                let k = report.stats()
+                let k = report
+                    .stats()
                     .keys()
                     .find(|k| k.name() == "stroke_len")
                     .expect("expeced stat");
@@ -339,7 +353,8 @@ mod tests {
                 assert!(report.stats().contains_key(&k));
             }
             {
-                let k = report.stats()
+                let k = report
+                    .stats()
                     .keys()
                     .find(|k| k.name() == "tree_len")
                     .expect("expeced stat");
@@ -360,7 +375,8 @@ mod tests {
         {
             let report = reporter.take();
             {
-                let k = report.counters()
+                let k = report
+                    .counters()
                     .keys()
                     .find(|k| k.name() == "happy_accidents")
                     .expect("expected counter");
@@ -368,17 +384,22 @@ mod tests {
                 assert_eq!(report.counters().get(&k), Some(&1));
             }
             {
-                let k = report.gauges()
+                let k = report
+                    .gauges()
                     .keys()
                     .find(|k| k.name() == "paint_level")
                     .expect("expected gauge");
                 assert_eq!(k.labels.get("joy"), Some(&"painting".to_string()));
                 assert_eq!(report.gauges().get(&k), Some(&2));
             }
-            assert_eq!(report.gauges().keys().find(|k| k.name() == "brush_width"),
+            assert_eq!(report
+                           .gauges()
+                           .keys()
+                           .find(|k| k.name() == "brush_width"),
                        None);
             {
-                let k = report.stats()
+                let k = report
+                    .stats()
                     .keys()
                     .find(|k| k.name() == "stroke_len")
                     .expect("expected stat");
@@ -394,17 +415,22 @@ mod tests {
         {
             let report = reporter.take();
             {
-                let k = report.counters()
+                let k = report
+                    .counters()
                     .keys()
                     .find(|k| k.name() == "happy_accidents")
                     .expect("expected counter");
                 assert_eq!(k.labels.get("joy"), Some(&"painting".to_string()));
                 assert_eq!(report.counters().get(&k), Some(&3));
             }
-            assert_eq!(report.gauges().keys().find(|k| k.name() == "paint_level"),
+            assert_eq!(report
+                           .gauges()
+                           .keys()
+                           .find(|k| k.name() == "paint_level"),
                        None);
             {
-                let k = report.gauges()
+                let k = report
+                    .gauges()
                     .keys()
                     .find(|k| k.name() == "brush_width")
                     .expect("expected gauge");
@@ -414,7 +440,8 @@ mod tests {
             assert_eq!(report.stats().keys().find(|k| k.name() == "stroke_len"),
                        None);
             {
-                let k = report.stats()
+                let k = report
+                    .stats()
                     .keys()
                     .find(|k| k.name() == "tree_len")
                     .expect("expeced stat");

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -31,7 +31,7 @@ pub fn format<R: Report>(report: &R) -> String {
 
     for (k, h) in report.stats() {
         let name = k.name();
-        let labels = &{
+        let labels = {
             let labels = k.labels();
             if labels.is_empty() {
                 "".to_string()
@@ -39,6 +39,7 @@ pub fn format<R: Report>(report: &R) -> String {
                 format!(", {}", format_labels(labels))
             }
         };
+        let labels = &labels;
         out.push_str(&format_stat("count", name, labels, h.count()));
         out.push_str(&format_stat("mean", name, labels, h.mean()));
         out.push_str(&format_stat("min", name, labels, h.min()));

--- a/src/report.rs
+++ b/src/report.rs
@@ -22,9 +22,15 @@ pub struct Reporter {
 impl Reporter {
     /// Obtains a read-only view of a metrics report without clearing the underlying state.
     pub fn peek(&self) -> ReportPeek {
-        let counters = self.counters.read().expect("failed to obtain read lock for counters");
-        let gauges = self.gauges.read().expect("failed to obtain read lock for gauges");
-        let stats = self.stats.read().expect("failed to obtain read lock for stats");
+        let counters = self.counters
+            .read()
+            .expect("failed to obtain read lock for counters");
+        let gauges = self.gauges
+            .read()
+            .expect("failed to obtain read lock for gauges");
+        let stats = self.stats
+            .read()
+            .expect("failed to obtain read lock for stats");
         ReportPeek {
             counters: counters,
             gauges: gauges,
@@ -38,7 +44,9 @@ impl Reporter {
     pub fn take(&mut self) -> ReportTake {
         // Copy counters.
         let counters: CounterMap = {
-            let orig = self.counters.read().expect("failed to obtain write lock for counters");
+            let orig = self.counters
+                .read()
+                .expect("failed to obtain write lock for counters");
             let mut snap = CounterMap::default();
             for (k, v) in orig.iter() {
                 snap.insert(k.clone(), *v);
@@ -48,7 +56,9 @@ impl Reporter {
 
         // Reset gauges.
         let gauges = {
-            let mut orig = self.gauges.write().expect("failed to obtain write lock for gauges");
+            let mut orig = self.gauges
+                .write()
+                .expect("failed to obtain write lock for gauges");
             let mut snap = GaugeMap::default();
             for (k, v) in orig.drain() {
                 snap.insert(k, v);
@@ -58,7 +68,9 @@ impl Reporter {
 
         // Reset stats.
         let stats = {
-            let mut orig = self.stats.write().expect("failed to obtain write lock for stats");
+            let mut orig = self.stats
+                .write()
+                .expect("failed to obtain write lock for stats");
             let mut snap = StatMap::default();
             for (k, v) in orig.drain() {
                 snap.insert(k, v);


### PR DESCRIPTION
Now there's no reason to mention tokio/futures in the description, nor depend
on these libraries.

Finally, rustfmt the world.