### PR TITLE
switching out HashMap for OrderMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 hdrsample = "3.0"
 twox-hash = "1.0"
 log = "0.3"
+ordermap = "0.2.10"
 
 [dev-dependencies]
 tokio-timer = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tacho"
 description = "A prometheus-focused metrics library"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Steve Jenson <stevej@buoyant.io>",
            "Oliver Gould <oliver@buoyant.io>"]
 repository = "https://github.com/BuoyantIO/tacho"

--- a/examples/multithread.rs
+++ b/examples/multithread.rs
@@ -37,7 +37,7 @@ fn main() {
 
         let spawn_start = Timing::start();
         thread::spawn(move || {
-            for i in 0..1_000_000 {
+            for i in 0..100_000_000 {
                 let loop_start = Timing::start();
                 loop_counter.incr(1);
                 loop_gauge.set(i);
@@ -81,12 +81,10 @@ fn reporter<D>(interval: Duration, done: D, reporter: tacho::Reporter) -> BoxFut
                           Ok(())
                       })
     };
-    let done = done.map(move |_| { print_report(&reporter.peek()); });
-    periodic
-        .select(done)
-        .map(|_| {})
-        .map_err(|_| {})
-        .boxed()
+    let done = done.map(move |_| {
+        print_report(&reporter.peek());
+    });
+    periodic.select(done).map(|_| {}).map_err(|_| {}).boxed()
 }
 
 fn print_report<R: tacho::Report>(report: &R) {

--- a/examples/multithread.rs
+++ b/examples/multithread.rs
@@ -81,10 +81,12 @@ fn reporter<D>(interval: Duration, done: D, reporter: tacho::Reporter) -> BoxFut
                           Ok(())
                       })
     };
-    let done = done.map(move |_| {
-        print_report(&reporter.peek());
-    });
-    periodic.select(done).map(|_| {}).map_err(|_| {}).boxed()
+    let done = done.map(move |_| { print_report(&reporter.peek()); });
+    periodic
+        .select(done)
+        .map(|_| {})
+        .map_err(|_| {})
+        .boxed()
 }
 
 fn print_report<R: tacho::Report>(report: &R) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,11 @@ extern crate hdrsample;
 #[macro_use]
 extern crate log;
 extern crate twox_hash;
+extern crate ordermap;
 
 use hdrsample::Histogram;
+use ordermap::OrderMap;
 use std::collections::BTreeMap;
-use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use twox_hash::RandomXxHashBuilder;
 
@@ -35,9 +36,9 @@ pub use report::{Reporter, Report, ReportTake, ReportPeek};
 pub use timing::Timing;
 
 type Labels = BTreeMap<String, String>;
-type CounterMap = HashMap<Key, u64, RandomXxHashBuilder>;
-type GaugeMap = HashMap<Key, u64, RandomXxHashBuilder>;
-type StatMap = HashMap<Key, Histogram<u64>, RandomXxHashBuilder>;
+type CounterMap = OrderMap<Key, u64, RandomXxHashBuilder>;
+type GaugeMap = OrderMap<Key, u64, RandomXxHashBuilder>;
+type StatMap = OrderMap<Key, Histogram<u64>, RandomXxHashBuilder>;
 
 /// Creates a metrics registry.
 ///

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,5 +1,5 @@
-use std::sync::{Arc, RwLock, RwLockReadGuard};
 use super::{CounterMap, GaugeMap, StatMap};
+use std::sync::{Arc, RwLock, RwLockReadGuard};
 
 pub fn new(counters: Arc<RwLock<CounterMap>>,
            gauges: Arc<RwLock<GaugeMap>>,

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,5 +1,5 @@
-use super::{CounterMap, GaugeMap, StatMap};
 use std::sync::{Arc, RwLock, RwLockReadGuard};
+use super::{CounterMap, GaugeMap, StatMap};
 
 pub fn new(counters: Arc<RwLock<CounterMap>>,
            gauges: Arc<RwLock<GaugeMap>>,
@@ -60,7 +60,7 @@ impl Reporter {
                 .write()
                 .expect("failed to obtain write lock for gauges");
             let mut snap = GaugeMap::default();
-            for (k, v) in orig.drain() {
+            for (k, v) in orig.drain(..) {
                 snap.insert(k, v);
             }
             snap
@@ -72,7 +72,7 @@ impl Reporter {
                 .write()
                 .expect("failed to obtain write lock for stats");
             let mut snap = StatMap::default();
-            for (k, v) in orig.drain() {
+            for (k, v) in orig.drain(..) {
                 snap.insert(k, v);
             }
             snap


### PR DESCRIPTION
Switching to OrderMap shaves 15 seconds off the `multithread` benchmark. (75 seconds vs 90 seconds)

One change here is that I don't delete all the keys each time, I only reset the values.