### PR TITLE
Use AtomicU64 for counters and gauges

### DIFF
--- a/examples/multithread.rs
+++ b/examples/multithread.rs
@@ -30,9 +30,9 @@ fn main() {
     };
     {
         let metrics = metrics.clone().labeled("role".into(), "worker".into());
-        let mut total_time_ms = metrics.gauge("total_time_ms".into());
-        let mut loop_counter = metrics.counter("loop_iters_count".into());
-        let mut loop_gauge = metrics.gauge("loop_iters_curr".into());
+        let total_time_ms = metrics.gauge("total_time_ms".into());
+        let loop_counter = metrics.counter("loop_iters_count".into());
+        let loop_gauge = metrics.gauge("loop_iters_curr".into());
         let mut loop_time_us = metrics.stat("loop_time_us".into());
 
         let spawn_start = Timing::start();
@@ -50,7 +50,7 @@ fn main() {
 
     let heartbeat = {
         let metrics = metrics.labeled("role".into(), "heartbeat".into());
-        let mut heartbeats = metrics.gauge("heartbeats".into());
+        let heartbeats = metrics.gauge("heartbeats".into());
         Timer::default()
             .interval(Duration::from_secs(1))
             .fold(0, move |i, _| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,7 @@ mod tests {
                     .find(|k| k.name() == "happy_accidents")
                     .expect("expected counter");
                 assert_eq!(k.labels.get("joy"), Some(&"painting".to_string()));
-                assert_eq!(report.gauges().get(&k).map(|g| g.load(Ordering::Relaxed)),
+                assert_eq!(report.counters().get(&k).map(|g| g.load(Ordering::Relaxed)),
                            Some(3));
             }
             {
@@ -382,7 +382,8 @@ mod tests {
                     .find(|k| k.name() == "happy_accidents")
                     .expect("expected counter");
                 assert_eq!(k.labels.get("joy"), Some(&"painting".to_string()));
-                assert_eq!(report.counters().get(&k), Some(&1));
+                assert_eq!(report.counters().get(&k).map(|c| c.load(Ordering::Relaxed)),
+                           Some(1));
             }
             {
                 let k = report
@@ -421,7 +422,7 @@ mod tests {
                     .expect("expected counter");
                 assert_eq!(k.labels.get("joy"), Some(&"painting".to_string()));
                 assert_eq!(report.counters().get(&k).map(|c| c.load(Ordering::Relaxed)),
-                           Some(&3));
+                           Some(3));
             }
             assert_eq!(report.gauges().keys().find(|k| k.name() == "paint_level"),
                        None);

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -1,6 +1,7 @@
 use super::Report;
 use std::collections::BTreeMap;
 use std::fmt::Display;
+use std::sync::atomic::Ordering;
 
 // The initial size
 const BUF_SIZE: usize = 8 * 1024;
@@ -12,6 +13,7 @@ pub fn format<R: Report>(report: &R) -> String {
     out.push_str(&format!("metrics_count {}\n", report.len()));
 
     for (k, v) in report.counters() {
+        let v = v.load(Ordering::Relaxed);
         let labels = k.labels();
         if labels.is_empty() {
             out.push_str(&format!("{} {}\n", k.name(), v));
@@ -21,6 +23,7 @@ pub fn format<R: Report>(report: &R) -> String {
     }
 
     for (k, v) in report.gauges() {
+        let v = v.load(Ordering::Relaxed);
         let labels = k.labels();
         if labels.is_empty() {
             out.push_str(&format!("{} {}\n", k.name(), v));

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,9 +1,9 @@
 use super::{CounterMap, GaugeMap, StatMap};
-use std::sync::{Arc, RwLock, RwLockReadGuard};
+use std::sync::{Arc, Mutex, MutexGuard};
 
-pub fn new(counters: Arc<RwLock<CounterMap>>,
-           gauges: Arc<RwLock<GaugeMap>>,
-           stats: Arc<RwLock<StatMap>>)
+pub fn new(counters: Arc<Mutex<CounterMap>>,
+           gauges: Arc<Mutex<GaugeMap>>,
+           stats: Arc<Mutex<StatMap>>)
            -> Reporter {
     Reporter {
         counters: counters,
@@ -14,22 +14,22 @@ pub fn new(counters: Arc<RwLock<CounterMap>>,
 
 #[derive(Clone)]
 pub struct Reporter {
-    counters: Arc<RwLock<CounterMap>>,
-    gauges: Arc<RwLock<GaugeMap>>,
-    stats: Arc<RwLock<StatMap>>,
+    counters: Arc<Mutex<CounterMap>>,
+    gauges: Arc<Mutex<GaugeMap>>,
+    stats: Arc<Mutex<StatMap>>,
 }
 
 impl Reporter {
     /// Obtains a read-only view of a metrics report without clearing the underlying state.
     pub fn peek(&self) -> ReportPeek {
         let counters = self.counters
-            .read()
+            .lock()
             .expect("failed to obtain read lock for counters");
         let gauges = self.gauges
-            .read()
+            .lock()
             .expect("failed to obtain read lock for gauges");
         let stats = self.stats
-            .read()
+            .lock()
             .expect("failed to obtain read lock for stats");
         ReportPeek {
             counters: counters,
@@ -45,11 +45,11 @@ impl Reporter {
         // Copy counters.
         let counters: CounterMap = {
             let orig = self.counters
-                .read()
+                .lock()
                 .expect("failed to obtain write lock for counters");
             let mut snap = CounterMap::default();
             for (k, v) in orig.iter() {
-                snap.insert(k.clone(), *v);
+                snap.insert(k.clone(), v.clone());
             }
             snap
         };
@@ -57,7 +57,7 @@ impl Reporter {
         // Reset gauges.
         let gauges = {
             let mut orig = self.gauges
-                .write()
+                .lock()
                 .expect("failed to obtain write lock for gauges");
             let mut snap = GaugeMap::default();
             for (k, v) in orig.drain(..) {
@@ -69,7 +69,7 @@ impl Reporter {
         // Reset stats.
         let stats = {
             let mut orig = self.stats
-                .write()
+                .lock()
                 .expect("failed to obtain write lock for stats");
             let mut snap = StatMap::default();
             for (k, v) in orig.drain(..) {
@@ -95,9 +95,9 @@ pub trait Report {
 }
 
 pub struct ReportPeek<'a> {
-    counters: RwLockReadGuard<'a, CounterMap>,
-    gauges: RwLockReadGuard<'a, GaugeMap>,
-    stats: RwLockReadGuard<'a, StatMap>,
+    counters: MutexGuard<'a, CounterMap>,
+    gauges: MutexGuard<'a, GaugeMap>,
+    stats: MutexGuard<'a, StatMap>,
 }
 impl<'a> Report for ReportPeek<'a> {
     fn counters(&self) -> &CounterMap {


### PR DESCRIPTION
Currently, tacho takes a mutex lock for all counter increments and gauge
writes. This is very slow.

By using the rust-nightly `integer_atomics` feature, we can substantially
improve throughput (by ~55.7%):

Previously:
```
target/release/examples/multithread  41.86s user 0.20s system 99% cpu 42.469 total
```

Now:
```
target/release/examples/multithread  18.53s user 0.03s system 99% cpu 18.627 total
```

I think I'd prefer to take a rust-nightly dependancy than accept this
performance hit. At least for the time being.