### PR TITLE
Report histogram percentiles properly.

### DIFF
--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -45,12 +45,12 @@ pub fn format<R: Report>(report: &R) -> String {
         out.push_str(&format_stat("min", name, labels, h.min()));
         out.push_str(&format_stat("max", name, labels, h.max()));
         out.push_str(&format_stat("stddev", name, labels, h.stdev()));
-        out.push_str(&format_stat("p50", name, labels, h.value_at_percentile(0.5)));
-        out.push_str(&format_stat("p90", name, labels, h.value_at_percentile(0.9)));
-        out.push_str(&format_stat("p95", name, labels, h.value_at_percentile(0.95)));
-        out.push_str(&format_stat("p99", name, labels, h.value_at_percentile(0.99)));
-        out.push_str(&format_stat("p999", name, labels, h.value_at_percentile(0.999)));
-        out.push_str(&format_stat("p9999", name, labels, h.value_at_percentile(0.9999)));
+        out.push_str(&format_stat("p50", name, labels, h.value_at_percentile(50.0)));
+        out.push_str(&format_stat("p90", name, labels, h.value_at_percentile(90.0)));
+        out.push_str(&format_stat("p95", name, labels, h.value_at_percentile(95.0)));
+        out.push_str(&format_stat("p99", name, labels, h.value_at_percentile(99.0)));
+        out.push_str(&format_stat("p999", name, labels, h.value_at_percentile(99.9)));
+        out.push_str(&format_stat("p9999", name, labels, h.value_at_percentile(99.99)));
     }
 
     out

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -9,8 +9,6 @@ const BUF_SIZE: usize = 8 * 1024;
 pub fn format<R: Report>(report: &R) -> String {
     let mut out = String::with_capacity(BUF_SIZE);
 
-    out.push_str(&format!("metrics_count {}\n", report.len()));
-
     for (k, v) in report.counters() {
         let labels = k.labels();
         if labels.is_empty() {
@@ -41,7 +39,6 @@ pub fn format<R: Report>(report: &R) -> String {
         };
         let labels = &labels;
         out.push_str(&format_stat("count", name, labels, h.count()));
-        out.push_str(&format_stat("mean", name, labels, h.mean()));
         out.push_str(&format_stat("min", name, labels, h.min()));
         out.push_str(&format_stat("max", name, labels, h.max()));
         out.push_str(&format_stat("stddev", name, labels, h.stdev()));


### PR DESCRIPTION
There was a bug wherein all stat percentiles were drastically underreported. We
reported the 0.5'th percentile instead of the 50th percentile, etc.

Using the proper percentile values yields proper results.