### PR TITLE
Improve performance and usability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tacho"
-description = "A prometheus-focused metrics library"
-version = "0.3.1"
+description = "A prometheus-focused metrics library for Future-aware applications"
+version = "0.4.0"
 authors = ["Steve Jenson <stevej@buoyant.io>",
            "Oliver Gould <oliver@buoyant.io>"]
 repository = "https://github.com/BuoyantIO/tacho"
@@ -9,13 +9,12 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
+futures = "0.1"
 hdrsample = "3.0"
-twox-hash = "1.0"
 log = "0.3"
 ordermap = "0.2.10"
 
 [dev-dependencies]
 tokio-timer = "0.1"
-futures = "0.1"
 tokio-core = "0.1"
 pretty_env_logger = "0.1"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Tacho #
 
-A [Prometheus][prom]-focused metrics library for Rust.
+A [Prometheus][prom]-focused metrics library for [Future-aware][futures-rs] Rust applications.
 
 - Inspired by [finagle-stats][finagle].
 - Supports [Prometheus][prom]-style labels and formatting.
+- Supports scoped.
+- Future-aware timing histograms.
 - Thread-safe.
 
 ## License ##
@@ -16,4 +18,5 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 [finagle]: https://github.com/twitter/finagle
+[futures-rs]: https://github.com/alexcrichton/futures-rs
 [prom]: https://prometheus.io

--- a/examples/multithread.rs
+++ b/examples/multithread.rs
@@ -32,15 +32,13 @@ fn main() {
         reporter(interval, work_done_rx, report)
     };
 
-    let metrics = metrics
-        .clone()
-        .labeled("test".into(), "multithread_stat".into());
-    let loop_iter_us = metrics.stat("loop_iter_us".into());
+    let metrics = metrics.clone().labeled("test", "multithread");
+    let loop_iter_us = metrics.stat("loop_iter_us");
     for (i, work_done_tx) in vec![(0, work_done_tx0), (1, work_done_tx1)] {
         let metrics = metrics.clone().labeled("thread".into(), format!("{}", i));
-        let mut loop_counter = metrics.counter("loop_counter".into());
-        let mut current_iter = metrics.gauge("current_iter".into());
-        let mut loop_iter_us = loop_iter_us.clone();
+        let loop_counter = metrics.counter("loop_counter".into());
+        let current_iter = metrics.gauge("current_iter".into());
+        let loop_iter_us = loop_iter_us.clone();
         thread::spawn(move || {
             let mut prior = None;
             for i in 0..10_000_000 {
@@ -82,6 +80,7 @@ fn reporter<D>(interval: Duration, done: D, reporter: tacho::Reporter) -> BoxFut
     periodic.select(done).map(|_| {}).map_err(|_| {}).boxed()
 }
 
-fn print_report<R: tacho::Report>(report: &R) {
-    info!("\n{}", tacho::prometheus::format(report));
+fn print_report(report: &tacho::Report) {
+    let out = tacho::prometheus::string(report).unwrap();
+    info!("\n{}", out);
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -34,7 +34,7 @@ fn do_work(metrics: tacho::Scope) -> future::BoxFuture<(), ()> {
     let metrics = metrics.labeled("labelkey", "labelval");
     let iter_time_us = metrics.stat("iter_time_us".into());
     let timer = Timer::default();
-    future::loop_fn(100, move |n| {
+    let work = future::loop_fn(100, move |n| {
         // Clones are shallow, minimizing allocation.
         let iter_time_us = iter_time_us.clone();
 
@@ -48,7 +48,6 @@ fn do_work(metrics: tacho::Scope) -> future::BoxFuture<(), ()> {
                      iter_time_us.add(start.elapsed_us());
                      future::Loop::Continue(n - 1)
                  })
-    })
-            .map(|_| {})
-            .boxed()
+    });
+    work.map(|_| {}).boxed()
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -22,7 +22,7 @@ fn main() {
                      let r = reporter.peek();
                      println!("# metrics:");
                      println!("");
-                     println!("{}", tacho::prometheus::format(&r));
+                     println!("{}", tacho::prometheus::string(&r).unwrap());
                  })
     });
 
@@ -31,12 +31,12 @@ fn main() {
 }
 
 fn do_work(metrics: tacho::Scope) -> future::BoxFuture<(), ()> {
-    let metrics = metrics.labeled("labelkey".into(), "labelval".into());
+    let metrics = metrics.labeled("labelkey", "labelval");
     let iter_time_us = metrics.stat("iter_time_us".into());
     let timer = Timer::default();
     future::loop_fn(100, move |n| {
         // Clones are shallow, minimizing allocation.
-        let mut iter_time_us = iter_time_us.clone();
+        let iter_time_us = iter_time_us.clone();
 
         let start = Timing::start();
         timer

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -1,72 +1,178 @@
 use super::Report;
-use std::collections::BTreeMap;
-use std::fmt::Display;
+use hdrsample::Histogram;
+use std::fmt;
+use std::sync::Arc;
 
-// The initial size
-const BUF_SIZE: usize = 8 * 1024;
+pub fn string(report: &Report) -> Result<String, fmt::Error> {
+    let mut out = String::with_capacity(8 * 1024);
+    write(&mut out, report)?;
+    Ok(out)
+}
 
 /// Renders a `Report` for Prometheus.
-pub fn format<R: Report>(report: &R) -> String {
-    let mut out = String::with_capacity(BUF_SIZE);
-
+pub fn write<W>(out: &mut W, report: &Report) -> fmt::Result
+    where W: fmt::Write
+{
     for (k, v) in report.counters() {
-        let labels = k.labels();
-        if labels.is_empty() {
-            out.push_str(&format!("{} {}\n", k.name(), v));
-        } else {
-            out.push_str(&format!("{}{{{}}} {}\n", k.name(), &format_labels(labels), v));
-        }
+        let name = FmtName::new(k.prefix(), k.name());
+        write_metric(out, &name, &k.labels().into(), v)?;
     }
 
     for (k, v) in report.gauges() {
-        let labels = k.labels();
-        if labels.is_empty() {
-            out.push_str(&format!("{} {}\n", k.name(), v));
-        } else {
-            out.push_str(&format!("{}{{{}}} {}\n", k.name(), &format_labels(labels), v));
-        }
+        let name = FmtName::new(k.prefix(), k.name());
+        write_metric(out, &name, &k.labels().into(), v)?;
     }
 
     for (k, h) in report.stats() {
-        let name = k.name();
-        let labels = {
-            let labels = k.labels();
-            if labels.is_empty() {
-                "".to_string()
-            } else {
-                format!(", {}", format_labels(labels))
-            }
-        };
-        let labels = &labels;
-        out.push_str(&format_stat("count", name, labels, h.count()));
-        out.push_str(&format_stat("min", name, labels, h.min()));
-        out.push_str(&format_stat("max", name, labels, h.max()));
-        out.push_str(&format_stat("stddev", name, labels, h.stdev()));
-        out.push_str(&format_stat("p50", name, labels, h.value_at_percentile(50.0)));
-        out.push_str(&format_stat("p90", name, labels, h.value_at_percentile(90.0)));
-        out.push_str(&format_stat("p95", name, labels, h.value_at_percentile(95.0)));
-        out.push_str(&format_stat("p99", name, labels, h.value_at_percentile(99.0)));
-        out.push_str(&format_stat("p999", name, labels, h.value_at_percentile(99.9)));
-        out.push_str(&format_stat("p9999", name, labels, h.value_at_percentile(99.99)));
+        let name = FmtName::new(k.prefix(), k.name());
+        let labels = k.labels().into();
+        write_buckets(out, &name, &labels, h.histogram())?;
+        write_metric(out, &format_args!("{}_{}", name, "min"), &labels, &h.min())?;
+        write_metric(out, &format_args!("{}_{}", name, "max"), &labels, &h.max())?;
+        write_metric(out, &format_args!("{}_{}", name, "sum"), &labels, &h.sum())?;
+        write_metric(out,
+                     &format_args!("{}_{}", name, "count"),
+                     &labels,
+                     &h.count())?;
     }
 
-    out
+    Ok(())
 }
 
-fn format_stat<V: Display>(stat: &str, name: &str, labels: &str, v: V) -> String {
-    let out = format!("{}{{stat=\"{}\"{}}} {}\n", name, stat, labels, v);
-    drop(v); // this is really just to appease clippy.
-    out
+fn write_buckets<N, W>(out: &mut W,
+                       name: &N,
+                       labels: &FmtLabels,
+                       h: &Histogram<usize>)
+                       -> fmt::Result
+    where N: fmt::Display,
+          W: fmt::Write
+{
+    // `Histogram` tracks buckets as a sequence of minimum values and incremental counts,
+    // however prometheus expects maximum values with cumulative counts.
+    //
+    // XXX Currently, we use the highest-granularity histogram available. This probably
+    // isn't practical.
+    let mut accum = 0;
+    let mut count = 0;
+    for bucket in h.iter_recorded() {
+        if count > 0 {
+            write_bucket(out, name, labels, &(bucket.value() - 1), accum)?;
+        }
+        count = bucket.count_at_value();
+        accum += count;
+    }
+    if count > 0 {
+        write_bucket(out, name, labels, &h.max(), accum)?; // Be explicit about the last bucket.
+    }
+    if accum > 0 {
+        write_bucket(out, name, labels, &"+Inf", accum)?; // Required to tell prom that the total count.
+    }
+    Ok(())
 }
 
-fn format_labels(labels: &BTreeMap<String, String>) -> String {
-    let mut out = String::with_capacity(16 * 1024);
-    let sz = labels.len();
-    for (i, (k, v)) in labels.iter().enumerate() {
-        out.push_str(&format!("{}=\"{}\"", k, v));
-        if i < sz - 1 {
-            out.push_str(", ");
+fn write_bucket<N, M, W>(out: &mut W,
+                         name: &N,
+                         labels: &FmtLabels,
+                         le: &M,
+                         count: usize)
+                         -> fmt::Result
+    where N: fmt::Display,
+          M: fmt::Display,
+          W: fmt::Write
+{
+    write_metric(out,
+                 &format_args!("{}_bucket", name),
+                 &labels.with_extra("le", format_args!("{}", le)),
+                 &count)
+}
+
+fn write_metric<W, N, V>(out: &mut W, name: &N, labels: &FmtLabels, v: &V) -> fmt::Result
+    where W: fmt::Write,
+          N: fmt::Display,
+          V: fmt::Display
+{
+    writeln!(out, "{}{} {}", name, labels, v)
+}
+
+fn write_prefix<W>(out: &mut W, prefix: Arc<super::Prefix>) -> fmt::Result
+    where W: fmt::Write
+{
+    if let super::Prefix::Node { ref prefix, value } = *prefix {
+        write_prefix(out, prefix.clone())?;
+        write!(out, "{}:", value)?;
+    }
+    Ok(())
+}
+
+/// Formats a prefixed name.
+struct FmtName<'a> {
+    prefix: &'a Arc<super::Prefix>,
+    name: &'a str,
+}
+
+impl<'a> FmtName<'a> {
+    fn new(prefix: &'a Arc<super::Prefix>, name: &'a str) -> Self {
+        FmtName { prefix, name }
+    }
+}
+
+impl<'a> fmt::Display for FmtName<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_prefix(f, self.prefix.clone())?;
+        write!(f, "{}", self.name)?;
+        Ok(())
+    }
+}
+
+impl<'a> From<&'a super::Labels> for FmtLabels<'a> {
+    fn from(base: &'a super::Labels) -> Self {
+        FmtLabels { base, extra: None }
+    }
+}
+
+/// Formats labels.
+struct FmtLabels<'a> {
+    /// Labels from the original Key.
+    base: &'a super::Labels,
+    /// An export-specific label (for buckets, etc).
+    extra: Option<(&'static str, fmt::Arguments<'a>)>,
+}
+
+impl<'a> FmtLabels<'a> {
+    fn is_empty(&self) -> bool {
+        self.base.is_empty() && self.extra.is_none()
+    }
+
+    /// Creates a new FmtLabels sharing a common `base` with a new copy of `extra`.
+    fn with_extra(&'a self, k: &'static str, v: fmt::Arguments<'a>) -> FmtLabels<'a> {
+        FmtLabels {
+            base: self.base,
+            extra: Some((k, v)),
         }
     }
-    out
+}
+
+impl<'a> fmt::Display for FmtLabels<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.is_empty() {
+            return Ok(());
+        }
+
+        let mut first = true;
+        write!(f, "{{")?;
+        if let Some((k, v)) = self.extra {
+            write!(f, "{}=\"{}\"", k, v)?;
+            first = false;
+        }
+        for (k, v) in self.base.iter() {
+            if !first {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}=\"{}\"", k, v)?;
+            first = false;
+        }
+        write!(f, "}}")?;
+
+        Ok(())
+    }
 }

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -62,10 +62,12 @@ fn write_buckets<N, W>(out: &mut W,
         accum += count;
     }
     if count > 0 {
-        write_bucket(out, name, labels, &h.max(), accum)?; // Be explicit about the last bucket.
+        // Be explicit about the last bucket.
+        write_bucket(out, name, labels, &h.max(), accum)?;
     }
     if accum > 0 {
-        write_bucket(out, name, labels, &"+Inf", accum)?; // Required to tell prom that the total count.
+        // Required to tell prom that the total count.
+        write_bucket(out, name, labels, &"+Inf", accum)?;
     }
     Ok(())
 }


### PR DESCRIPTION
This change includes major changes identified while implementing linkerd-tcp:

- introduce micro-benchmarks so that performance investments may be assessed
  quantiatively;
- update the _multithread_ example to set metrics from multiple threads concurrently;
- use atomics for Counter & Gauge, removing locks in update path;
- use a fine-grained per-stat mutex to lessen contention in stat update path;
- use `&'static str` for all label keys and metric names;
- stop using the _twox_ hash, as it does not seem ot have an advantage when applied to our
  key structure;
- make label values implement std::fmt::Display;
- add key prefixes (namespaces) to Scope;
- export raw histogram buckets to prometheus;
- track histogram sums;
- introduce Timer/Timed to support measuring the amount of time it takes for an
  asynchronous operation to complete;
- and update the version to 0.4.0