### PR TITLE
Make tacho buildable with rust stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tacho"
 description = "A prometheus-focused metrics library for Future-aware applications"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Steve Jenson <stevej@buoyant.io>",
            "Oliver Gould <oliver@buoyant.io>"]
 repository = "https://github.com/BuoyantIO/tacho"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -19,11 +19,11 @@ fn main() {
             .sleep(Duration::from_millis(1000))
             .map_err(|_| {})
             .map(move |_| {
-                     let r = reporter.peek();
-                     println!("# metrics:");
-                     println!("");
-                     println!("{}", tacho::prometheus::string(&r).unwrap());
-                 })
+                let r = reporter.peek();
+                println!("# metrics:");
+                println!("");
+                println!("{}", tacho::prometheus::string(&r).unwrap());
+            })
     });
 
     let mut core = Core::new().expect("could not create core");
@@ -43,11 +43,11 @@ fn do_work(metrics: tacho::Scope) -> future::BoxFuture<(), ()> {
             .sleep(Duration::from_millis(20 * (n % 5)))
             .map_err(|_| {})
             .map(move |_| if n == 0 {
-                     future::Loop::Break(n)
-                 } else {
-                     iter_time_us.add(start.elapsed_us());
-                     future::Loop::Continue(n - 1)
-                 })
+                future::Loop::Break(n)
+            } else {
+                iter_time_us.add(start.elapsed_us());
+                future::Loop::Continue(n - 1)
+            })
     });
     work.map(|_| {}).boxed()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,14 @@
 //! Labels are stored in a `BTreeMap` because they are used as hash keys and, therefore,
 //! need to implement `Hash`.
 
-// For benchmarks.
-#![feature(test)]
+#[cfg_attr(test, feature(test))]
 
 extern crate futures;
 extern crate hdrsample;
 #[macro_use]
 extern crate log;
 extern crate ordermap;
+#[cfg(test)]
 extern crate test;
 
 use futures::{Future, Poll};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,9 +145,9 @@ impl Scope {
     /// Creates a Counter with the given name.
     pub fn counter(&self, name: &'static str) -> Counter {
         let key = Key::new(name, self.prefix.clone(), self.labels.clone());
-        let mut reg = self.registry
-            .lock()
-            .expect("failed to obtain lock on registry");
+        let mut reg = self.registry.lock().expect(
+            "failed to obtain lock on registry",
+        );
 
         if let Some(c) = reg.counters.get(&key) {
             return Counter(Arc::downgrade(c));
@@ -162,9 +162,9 @@ impl Scope {
     /// Creates a Gauge with the given name.
     pub fn gauge(&self, name: &'static str) -> Gauge {
         let key = Key::new(name, self.prefix.clone(), self.labels.clone());
-        let mut reg = self.registry
-            .lock()
-            .expect("failed to obtain lock on registry");
+        let mut reg = self.registry.lock().expect(
+            "failed to obtain lock on registry",
+        );
 
         if let Some(g) = reg.gauges.get(&key) {
             return Gauge(Arc::downgrade(g));
@@ -205,9 +205,9 @@ impl Scope {
     }
 
     fn mk_stat(&self, key: Key, bounds: Option<(u64, u64)>) -> Stat {
-        let mut reg = self.registry
-            .lock()
-            .expect("failed to obtain lock on registry");
+        let mut reg = self.registry.lock().expect(
+            "failed to obtain lock on registry",
+        );
 
         if let Some(h) = reg.stats.get(&key) {
             let histo = Arc::downgrade(h);
@@ -358,7 +358,8 @@ impl Timer {
     }
 
     pub fn time<F>(&self, fut: F) -> Timed<F>
-        where F: Future + 'static
+    where
+        F: Future + 'static,
     {
         let stat = self.stat.clone();
         let unit = self.unit;
@@ -367,9 +368,9 @@ impl Timer {
             // when the object is created).
             let t0 = Timing::start();
             fut.then(move |v| {
-                         stat.add(to_u64(t0, unit));
-                         v
-                     })
+                stat.add(to_u64(t0, unit));
+                v
+            })
         });
         Timed(Box::new(f))
     }
@@ -414,16 +415,16 @@ mod tests {
     fn bench_scope_clone_x1000(b: &mut Bencher) {
         let scopes = mk_scopes(1000, "bench_scope_clone_x1000");
         b.iter(move || for scope in &scopes {
-                   let _ = scope.clone();
-               });
+            let _ = scope.clone();
+        });
     }
 
     #[bench]
     fn bench_scope_label_x1000(b: &mut Bencher) {
         let scopes = mk_scopes(1000, "bench_scope_label_x1000");
         b.iter(move || for scope in &scopes {
-                   let _ = scope.clone().labeled("foo", "bar");
-               });
+            let _ = scope.clone().labeled("foo", "bar");
+        });
     }
 
     #[bench]
@@ -448,24 +449,24 @@ mod tests {
     fn bench_counter_create_x1000(b: &mut Bencher) {
         let scopes = mk_scopes(1000, "bench_counter_create_x1000");
         b.iter(move || for scope in &scopes {
-                   scope.counter(DEFAULT_METRIC_NAME);
-               });
+            scope.counter(DEFAULT_METRIC_NAME);
+        });
     }
 
     #[bench]
     fn bench_gauge_create_x1000(b: &mut Bencher) {
         let scopes = mk_scopes(1000, "bench_gauge_create_x1000");
         b.iter(move || for scope in &scopes {
-                   scope.gauge(DEFAULT_METRIC_NAME);
-               });
+            scope.gauge(DEFAULT_METRIC_NAME);
+        });
     }
 
     #[bench]
     fn bench_stat_create_x1000(b: &mut Bencher) {
         let scopes = mk_scopes(1000, "bench_stat_create_x1000");
         b.iter(move || for scope in &scopes {
-                   scope.stat(DEFAULT_METRIC_NAME);
-               });
+            scope.stat(DEFAULT_METRIC_NAME);
+        });
     }
 
     #[bench]
@@ -496,8 +497,8 @@ mod tests {
             .map(|s| s.counter(DEFAULT_METRIC_NAME))
             .collect();
         b.iter(move || for c in &counters {
-                   c.incr(1)
-               });
+            c.incr(1)
+        });
     }
 
     #[bench]
@@ -507,8 +508,8 @@ mod tests {
             .map(|s| s.gauge(DEFAULT_METRIC_NAME))
             .collect();
         b.iter(move || for g in &gauges {
-                   g.set(1)
-               });
+            g.set(1)
+        });
     }
 
     #[bench]
@@ -518,8 +519,8 @@ mod tests {
             .map(|s| s.stat(DEFAULT_METRIC_NAME))
             .collect();
         b.iter(move || for s in &stats {
-                   s.add(1)
-               });
+            s.add(1)
+        });
     }
 
     #[bench]
@@ -529,16 +530,16 @@ mod tests {
             metrics.stat(DEFAULT_METRIC_NAME)
         };
         b.iter(move || for i in 0..1000 {
-                   s.add(i)
-               });
+            s.add(i)
+        });
     }
 
     fn mk_scopes(n: usize, name: &str) -> Vec<Scope> {
         let (metrics, _) = super::new();
-        let metrics = metrics
-            .prefixed("t")
-            .labeled("test_name", name)
-            .labeled("total_iterations", n);
+        let metrics = metrics.prefixed("t").labeled("test_name", name).labeled(
+            "total_iterations",
+            n,
+        );
         (0..n)
             .map(|i| metrics.clone().labeled("iteration", format!("{}", i)))
             .collect()
@@ -577,8 +578,10 @@ mod tests {
                 assert_eq!(k.labels.get("joy"), Some(&"painting".to_string()));
                 assert_eq!(report.gauges().get(&k), Some(&2));
             }
-            assert_eq!(report.gauges().keys().find(|k| k.name() == "brush_width"),
-                       None);
+            assert_eq!(
+                report.gauges().keys().find(|k| k.name() == "brush_width"),
+                None
+            );
             {
                 let k = report
                     .stats()
@@ -681,8 +684,10 @@ mod tests {
                 assert_eq!(k.labels.get("joy"), Some(&"painting".to_string()));
                 assert_eq!(report.gauges().get(&k), Some(&2));
             }
-            assert_eq!(report.gauges().keys().find(|k| k.name() == "brush_width"),
-                       None);
+            assert_eq!(
+                report.gauges().keys().find(|k| k.name() == "brush_width"),
+                None
+            );
             {
                 let k = report
                     .stats()
@@ -753,8 +758,10 @@ mod tests {
                 assert_eq!(k.labels.get("joy"), Some(&"painting".to_string()));
                 assert_eq!(report.counters().get(&k), Some(&3));
             }
-            assert_eq!(report.gauges().keys().find(|k| k.name() == "paint_level"),
-                       None);
+            assert_eq!(
+                report.gauges().keys().find(|k| k.name() == "paint_level"),
+                None
+            );
             {
                 let k = report
                     .gauges()
@@ -764,8 +771,10 @@ mod tests {
                 assert_eq!(k.labels.get("joy"), Some(&"painting".to_string()));
                 assert_eq!(report.gauges().get(&k), Some(&5));
             }
-            assert_eq!(report.stats().keys().find(|k| k.name() == "stroke_len"),
-                       None);
+            assert_eq!(
+                report.stats().keys().find(|k| k.name() == "stroke_len"),
+                None
+            );
             {
                 let k = report
                     .stats()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@
 //! Labels are stored in a `BTreeMap` because they are used as hash keys and, therefore,
 //! need to implement `Hash`.
 
-#[cfg_attr(test, feature(test))]
+
+#![cfg_attr(test, feature(test))]
 
 extern crate futures;
 extern crate hdrsample;

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -11,7 +11,8 @@ pub fn string(report: &Report) -> Result<String, fmt::Error> {
 
 /// Renders a `Report` for Prometheus.
 pub fn write<W>(out: &mut W, report: &Report) -> fmt::Result
-    where W: fmt::Write
+where
+    W: fmt::Write,
 {
     for (k, v) in report.counters() {
         let name = FmtName::new(k.prefix(), k.name());
@@ -30,22 +31,26 @@ pub fn write<W>(out: &mut W, report: &Report) -> fmt::Result
         write_metric(out, &format_args!("{}_{}", name, "min"), &labels, &h.min())?;
         write_metric(out, &format_args!("{}_{}", name, "max"), &labels, &h.max())?;
         write_metric(out, &format_args!("{}_{}", name, "sum"), &labels, &h.sum())?;
-        write_metric(out,
-                     &format_args!("{}_{}", name, "count"),
-                     &labels,
-                     &h.count())?;
+        write_metric(
+            out,
+            &format_args!("{}_{}", name, "count"),
+            &labels,
+            &h.count(),
+        )?;
     }
 
     Ok(())
 }
 
-fn write_buckets<N, W>(out: &mut W,
-                       name: &N,
-                       labels: &FmtLabels,
-                       h: &Histogram<usize>)
-                       -> fmt::Result
-    where N: fmt::Display,
-          W: fmt::Write
+fn write_buckets<N, W>(
+    out: &mut W,
+    name: &N,
+    labels: &FmtLabels,
+    h: &Histogram<usize>,
+) -> fmt::Result
+where
+    N: fmt::Display,
+    W: fmt::Write,
 {
     // `Histogram` tracks buckets as a sequence of minimum values and incremental counts,
     // however prometheus expects maximum values with cumulative counts.
@@ -72,32 +77,38 @@ fn write_buckets<N, W>(out: &mut W,
     Ok(())
 }
 
-fn write_bucket<N, M, W>(out: &mut W,
-                         name: &N,
-                         labels: &FmtLabels,
-                         le: &M,
-                         count: usize)
-                         -> fmt::Result
-    where N: fmt::Display,
-          M: fmt::Display,
-          W: fmt::Write
+fn write_bucket<N, M, W>(
+    out: &mut W,
+    name: &N,
+    labels: &FmtLabels,
+    le: &M,
+    count: usize,
+) -> fmt::Result
+where
+    N: fmt::Display,
+    M: fmt::Display,
+    W: fmt::Write,
 {
-    write_metric(out,
-                 &format_args!("{}_bucket", name),
-                 &labels.with_extra("le", format_args!("{}", le)),
-                 &count)
+    write_metric(
+        out,
+        &format_args!("{}_bucket", name),
+        &labels.with_extra("le", format_args!("{}", le)),
+        &count,
+    )
 }
 
 fn write_metric<W, N, V>(out: &mut W, name: &N, labels: &FmtLabels, v: &V) -> fmt::Result
-    where W: fmt::Write,
-          N: fmt::Display,
-          V: fmt::Display
+where
+    W: fmt::Write,
+    N: fmt::Display,
+    V: fmt::Display,
 {
     writeln!(out, "{}{} {}", name, labels, v)
 }
 
 fn write_prefix<W>(out: &mut W, prefix: Arc<super::Prefix>) -> fmt::Result
-    where W: fmt::Write
+where
+    W: fmt::Write,
 {
     if let super::Prefix::Node { ref prefix, value } = *prefix {
         write_prefix(out, prefix.clone())?;


### PR DESCRIPTION
Previously, we used the #[feature(test)] pragma, which causes the project to
fail to build with rust stable. This is resolved by scoping this to the test
configuration with `#[cfg_attr(test, feature(test)]`.