### PR TITLE
Reset histogram metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,4 @@
+## 0.4.2 2017-06-26
+
+* Reset histogram min and max when the histogram is cleared.
+* When a histogram is zero, only the `_count` value is exported.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tacho"
 description = "A prometheus-focused metrics library for Future-aware applications"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Steve Jenson <stevej@buoyant.io>",
            "Oliver Gould <oliver@buoyant.io>"]
 repository = "https://github.com/BuoyantIO/tacho"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,7 +312,7 @@ impl HistogramWithSum {
     }
 
     pub fn clear(&mut self) {
-        self.histogram.clear();
+        self.histogram.reset();
         self.sum = 0;
     }
 }

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -27,16 +27,14 @@ where
     for (k, h) in report.stats() {
         let name = FmtName::new(k.prefix(), k.name());
         let labels = k.labels().into();
-        write_buckets(out, &name, &labels, h.histogram())?;
-        write_metric(out, &format_args!("{}_{}", name, "min"), &labels, &h.min())?;
-        write_metric(out, &format_args!("{}_{}", name, "max"), &labels, &h.max())?;
-        write_metric(out, &format_args!("{}_{}", name, "sum"), &labels, &h.sum())?;
-        write_metric(
-            out,
-            &format_args!("{}_{}", name, "count"),
-            &labels,
-            &h.count(),
-        )?;
+        let count = h.count();
+        write_metric(out, &format_args!("{}_{}", name, "count"), &labels, &count)?;
+        if count > 0 {
+            write_buckets(out, &name, &labels, h.histogram())?;
+            write_metric(out, &format_args!("{}_{}", name, "min"), &labels, &h.min())?;
+            write_metric(out, &format_args!("{}_{}", name, "max"), &labels, &h.max())?;
+            write_metric(out, &format_args!("{}_{}", name, "sum"), &labels, &h.sum())?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
`HistogramWithSum::clear()` does not clear min or max.  It should. Furthermore, only the histogram's `_count` value should be reported when the histogram is empty.