### PR TITLE
Fix clippy lint #[warn(cast_lossless)]

### DIFF
--- a/src/timing.rs
+++ b/src/timing.rs
@@ -13,10 +13,10 @@ impl Timing {
 
 impl Timing for Duration {
     fn elapsed_us(&self) -> u64 {
-        self.as_secs() as u64 * 1_000_000 + self.subsec_nanos() as u64 / 1_000
+        self.as_secs() as u64 * 1_000_000 + u64::from(self.subsec_nanos()) / 1_000
     }
     fn elapsed_ms(&self) -> u64 {
-        self.as_secs() as u64 * 1_000 + self.subsec_nanos() as u64 / 1_000_000
+        self.as_secs() as u64 * 1_000 + u64::from(self.subsec_nanos()) / 1_000_000
     }
 }
 


### PR DESCRIPTION
Problem:

Clippy warns that casting u32 to u64 could result in silent data loss
in the future and suggests switching to `u64::from`

Solution:

Switch to `u64::from`

Testing:

Ran the test suite and also compared `cargo bench` runs

```
/Users/stevej/src/tacho% cargo benchcmp master fix_cast                                          (git)-[master]
name                               master ns/iter  fix_cast ns/iter  diff ns/iter  diff %  speedup
 tests::bench_counter_create        147             151                          4   2.72%   x 0.97
 tests::bench_counter_create_x1000  462,708         419,139                -43,569  -9.42%   x 1.10
 tests::bench_counter_update        27              26                          -1  -3.70%   x 1.04
 tests::bench_counter_update_x1000  895             925                         30   3.35%   x 0.97
 tests::bench_gauge_create          147             147                          0   0.00%   x 1.00
 tests::bench_gauge_create_x1000    437,879         449,057                 11,178   2.55%   x 0.98
 tests::bench_gauge_update          18              17                          -1  -5.56%   x 1.06
 tests::bench_gauge_update_x1000    3,172           2,978                     -194  -6.12%   x 1.07
 tests::bench_scope_clone           64              65                           1   1.56%   x 0.98
 tests::bench_scope_clone_x1000     183,516         169,723                -13,793  -7.52%   x 1.08
 tests::bench_scope_label           166             154                        -12  -7.23%   x 1.08
 tests::bench_scope_label_x1000     282,204         289,021                  6,817   2.42%   x 0.98
 tests::bench_stat_add_x1000        2,763           2,704                      -59  -2.14%   x 1.02
 tests::bench_stat_create           149             145                         -4  -2.68%   x 1.03
 tests::bench_stat_create_x1000     514,363         476,825                -37,538  -7.30%   x 1.08
 tests::bench_stat_update           52              49                          -3  -5.77%   x 1.06
 tests::bench_stat_update_x1000     2,862           2,894                       32   1.12%   x 0.99
```