### PR TITLE
Improve performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ futures = "0.1"
 hdrsample = "3.0"
 log = "0.3"
 ordermap = "0.2.10"
+parking_lot = "0.4"
 
 [dev-dependencies]
 tokio-timer = "0.1"

--- a/src/report.rs
+++ b/src/report.rs
@@ -36,9 +36,9 @@ impl Reporter {
         };
 
         // Drop unreferenced metrics.
-        registry.counters.retain(|_, v| Arc::weak_count(v) > 0);
-        registry.gauges.retain(|_, v| Arc::weak_count(v) > 0);
-        registry.stats.retain(|_, v| Arc::weak_count(v) > 0);
+        registry.counters.retain(|_, v| Arc::strong_count(v) > 1);
+        registry.gauges.retain(|_, v| Arc::strong_count(v) > 1);
+        registry.stats.retain(|_, v| Arc::strong_count(v) > 1);
 
         report
     }


### PR DESCRIPTION
This significantly improve performance in the existing benchmarks.  Also includes a commit which fixes up some issues in the benchmarks.

Overall improvements:

```
 name                               control.txt ns/iter  hypothesis.txt ns/iter  diff ns/iter   diff %  speedup
 tests::bench_counter_create        212                  194                              -18   -8.49%   x 1.09
 tests::bench_counter_create_x1000  584,205              556,205                      -28,000   -4.79%   x 1.05
 tests::bench_counter_update        39                   10                               -29  -74.36%   x 3.90
 tests::bench_counter_update_x1000  31,769               12,114                       -19,655  -61.87%   x 2.62
 tests::bench_gauge_create          210                  194                              -16   -7.62%   x 1.08
 tests::bench_gauge_create_x1000    585,133              549,313                      -35,820   -6.12%   x 1.07
 tests::bench_gauge_update          28                   1                                -27  -96.43%  x 28.00
 tests::bench_gauge_update_x1000    21,815               3,244                        -18,571  -85.13%   x 6.72
 tests::bench_scope_clone           119                  119                                0    0.00%   x 1.00
 tests::bench_scope_clone_x1000     257,944              233,458                      -24,486   -9.49%   x 1.10
 tests::bench_scope_label           231                  229                               -2   -0.87%   x 1.01
 tests::bench_scope_label_x1000     383,160              358,697                      -24,463   -6.38%   x 1.07
 tests::bench_stat_add_x1000        68,646               29,070                       -39,576  -57.65%   x 2.36
 tests::bench_stat_create           208                  200                               -8   -3.85%   x 1.04
 tests::bench_stat_create_x1000     583,249              552,392                      -30,857   -5.29%   x 1.06
 tests::bench_stat_update           68                   29                               -39  -57.35%   x 2.34
 tests::bench_stat_update_x1000     68,031               29,308                       -38,723  -56.92%   x 2.32
```
Benchmarks run on a Xeon D-1540 with turbo boost disabled, Linux 4.12.5-300.fc26.x86_64, rustc 1.22.0-nightly (fd4bef54a 2017-09-15).